### PR TITLE
BUGFIX: Neos 9.0 compatibility

### DIFF
--- a/Classes/Aspect/CollectDebugInformationAspect.php
+++ b/Classes/Aspect/CollectDebugInformationAspect.php
@@ -16,13 +16,13 @@ namespace Flowpack\Neos\Debug\Aspect;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Flowpack\Neos\Debug\DataCollector\CacheAccessCollector;
+use Flowpack\Neos\Debug\DataCollector\ContentContextMetricsCollectorInterface;
 use Flowpack\Neos\Debug\DataCollector\MessagesCollector;
 use Flowpack\Neos\Debug\Domain\Model\Dto\ResourceStreamRequest;
 use Flowpack\Neos\Debug\Logging\DebugStack;
 use Flowpack\Neos\Debug\Service\DebugService;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
-use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\JoinPointInterface;
 use Neos\Flow\ResourceManagement\PersistentResource;
@@ -40,9 +40,6 @@ class CollectDebugInformationAspect
     protected DebugService $debugService;
 
     protected DebugStack $sqlLoggingStack;
-
-    #[Flow\Inject]
-    protected ContextFactoryInterface $contextFactory;
 
     protected int $contentCacheHits = 0;
 
@@ -66,6 +63,9 @@ class CollectDebugInformationAspect
 
     #[Flow\Inject]
     protected CacheAccessCollector $cacheAccessCollector;
+
+    #[Flow\Inject()]
+    protected ContentContextMetricsCollectorInterface $contentContextMetricsCollector;
 
     #[Flow\Pointcut("setting(Flowpack.Neos.Debug.enabled)")]
     public function debuggingActive(): void
@@ -120,24 +120,6 @@ class CollectDebugInformationAspect
 
         $groupedQueries = $this->groupQueries($this->sqlLoggingStack->queries);
 
-        // Analyse ContentContext
-        $contentContextMetrics = [];
-        foreach ($this->contextFactory->getInstances() as $contextIdentifier => $context) {
-            $firstLevelNodeCache = $context->getFirstLevelNodeCache();
-            $contentContextMetrics[$contextIdentifier] = [
-                'workspace' => $context->getWorkspace()->getName(),
-                'dimensions' => $context->getDimensions(),
-                'invisibleContentShown' => $context->isInvisibleContentShown(),
-                'removedContentShown' => $context->isRemovedContentShown(),
-                'inaccessibleContentShown' => $context->isInaccessibleContentShown(),
-                'firstLevelNodeCache' => [
-                    'nodesByPath' => count(ObjectAccess::getProperty($firstLevelNodeCache, 'nodesByPath', true)),
-                    'nodesByIdentifier' => count(ObjectAccess::getProperty($firstLevelNodeCache, 'nodesByIdentifier', true)),
-                    'childNodesByPathAndNodeTypeFilter' => count(ObjectAccess::getProperty($firstLevelNodeCache, 'childNodesByPathAndNodeTypeFilter', true)),
-                ],
-            ];
-        }
-
         // TODO: Introduce DTOs for the data
         $data = [
             'startRenderAt' => $startRenderAt,
@@ -160,7 +142,7 @@ class CollectDebugInformationAspect
                 // TODO: Iterate over all existing collectors
                 $this->messagesCollector->getName() => $this->messagesCollector->collect(),
                 $this->cacheAccessCollector->getName() => $this->cacheAccessCollector->collect(),
-                'contentContextMetrics' => $contentContextMetrics,
+                $this->contentContextMetricsCollector->getName() => $this->contentContextMetricsCollector->collect(),
             ]
         ];
 

--- a/Classes/DataCollector/ContentContextMetricsCollectorFactory.php
+++ b/Classes/DataCollector/ContentContextMetricsCollectorFactory.php
@@ -20,7 +20,7 @@ class ContentContextMetricsCollectorFactory
     public function build(): ?ContentContextMetricsCollectorInterface
     {
         // ContextFactory only exists before Neos 9.x
-        if (class_exists(\Neos\ContentRepository\Domain\Service\ContextFactoryInterface::class)) {
+        if (interface_exists(\Neos\ContentRepository\Domain\Service\ContextFactoryInterface::class)) {
             return new ContentContextMetricsCollectorNeos8(
                 $this->dataFormatter,
                 $this->objectManager->get(\Neos\ContentRepository\Domain\Service\ContextFactoryInterface::class)

--- a/Classes/DataCollector/ContentContextMetricsCollectorFactory.php
+++ b/Classes/DataCollector/ContentContextMetricsCollectorFactory.php
@@ -19,7 +19,7 @@ class ContentContextMetricsCollectorFactory
 
     public function build(): ?ContentContextMetricsCollectorInterface
     {
-        // ContextFactory only exists before Neos 9.x
+        // ContextFactoryInterface only exists before Neos 9.x
         if (interface_exists(\Neos\ContentRepository\Domain\Service\ContextFactoryInterface::class)) {
             return new ContentContextMetricsCollectorNeos8(
                 $this->dataFormatter,

--- a/Classes/DataCollector/ContentContextMetricsCollectorFactory.php
+++ b/Classes/DataCollector/ContentContextMetricsCollectorFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Neos\Debug\DataCollector;
+
+use Flowpack\Neos\Debug\DataFormatter\DataFormatterInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+
+class ContentContextMetricsCollectorFactory
+{
+    public function __construct(
+        protected ObjectManagerInterface $objectManager,
+        protected ?DataFormatterInterface $dataFormatter = null,
+    )
+    {
+    }
+
+    public function build(): ?ContentContextMetricsCollectorInterface
+    {
+        // ContextFactory only exists before Neos 9.x
+        if (class_exists(\Neos\ContentRepository\Domain\Service\ContextFactoryInterface::class)) {
+            return new ContentContextMetricsCollectorNeos8(
+                $this->dataFormatter,
+                $this->objectManager->get(\Neos\ContentRepository\Domain\Service\ContextFactoryInterface::class)
+            );
+        } else {
+            return new ContentContextMetricsCollectorNeos9(
+                $this->dataFormatter
+            );
+        }
+    }
+}

--- a/Classes/DataCollector/ContentContextMetricsCollectorInterface.php
+++ b/Classes/DataCollector/ContentContextMetricsCollectorInterface.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\Neos\Debug\DataCollector;
+
+interface ContentContextMetricsCollectorInterface
+{
+
+}

--- a/Classes/DataCollector/ContentContextMetricsCollectorNeos8.php
+++ b/Classes/DataCollector/ContentContextMetricsCollectorNeos8.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Neos\Debug\DataCollector;
+
+use Flowpack\Neos\Debug\DataFormatter\DataFormatterInterface;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Utility\ObjectAccess;
+
+class ContentContextMetricsCollectorNeos8 extends AbstractDataCollector implements ContentContextMetricsCollectorInterface
+{
+    public function __construct(
+        ?DataFormatterInterface $dataFormatter,
+        protected ContextFactoryInterface $contextFactory,
+    )
+    {
+        parent::__construct($dataFormatter);
+    }
+
+    public function getName(): string
+    {
+        return 'contentContextMetrics';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function collect(): array
+    {
+        // Analyse ContentContext
+        $contentContextMetrics = [];
+        foreach ($this->contextFactory->getInstances() as $contextIdentifier => $context) {
+            $firstLevelNodeCache = $context->getFirstLevelNodeCache();
+            $contentContextMetrics[$contextIdentifier] = [
+                'workspace' => $context->getWorkspace()->getName(),
+                'dimensions' => $context->getDimensions(),
+                'invisibleContentShown' => $context->isInvisibleContentShown(),
+                'removedContentShown' => $context->isRemovedContentShown(),
+                'inaccessibleContentShown' => $context->isInaccessibleContentShown(),
+                'firstLevelNodeCache' => [
+                    'nodesByPath' => count(ObjectAccess::getProperty($firstLevelNodeCache, 'nodesByPath', true)),
+                    'nodesByIdentifier' => count(ObjectAccess::getProperty($firstLevelNodeCache, 'nodesByIdentifier', true)),
+                    'childNodesByPathAndNodeTypeFilter' => count(ObjectAccess::getProperty($firstLevelNodeCache, 'childNodesByPathAndNodeTypeFilter', true)),
+                ],
+            ];
+        }
+        return $contentContextMetrics;
+    }
+}

--- a/Classes/DataCollector/ContentContextMetricsCollectorNeos9.php
+++ b/Classes/DataCollector/ContentContextMetricsCollectorNeos9.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Neos\Debug\DataCollector;
+
+use Flowpack\Neos\Debug\Domain\Model\Dto\CacheMonitorMetrics;
+use Neos\Flow\Annotations as Flow;
+
+class ContentContextMetricsCollectorNeos9 extends AbstractDataCollector implements ContentContextMetricsCollectorInterface
+{
+    public function getName(): string
+    {
+        return 'contentContextMetrics';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function collect(): array
+    {
+        return [];
+    }
+}

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,2 +1,7 @@
 Flowpack\Neos\Debug\DataFormatter\DataFormatterInterface:
   className: Flowpack\Neos\Debug\DataFormatter\DataFormatter
+
+Flowpack\Neos\Debug\DataCollector\ContentContextMetricsCollectorInterface:
+  scope: singleton
+  factoryObjectName: 'Flowpack\Neos\Debug\DataCollector\ContentContextMetricsCollectorFactory'
+  factoryMethodName: build


### PR DESCRIPTION
Moves the `ContentContextMetrics` into a dedicated DataCollector to not load it with Neos 9, as the ContentContext has been removed there.