### PR TITLE
BUGFIX: Correctly add up individual query counts and times by sql string

### DIFF
--- a/Classes/Aspect/CollectDebugInformationAspect.php
+++ b/Classes/Aspect/CollectDebugInformationAspect.php
@@ -253,7 +253,7 @@ class CollectDebugInformationAspect
                 ];
             }
 
-            if (!array_key_exists($sql, $carry[$table])) {
+            if (!array_key_exists($sql, $carry[$table]['queries'])) {
                 $carry[$table]['queries'][$sql] = [
                     'executionTimeSum' => 0,
                     'count' => 0,


### PR DESCRIPTION
Due to incorrect array access, the count for each query was always 1 and the execution time wasn't added up either