### PR TITLE
BUGFIX: Less strict html detection

### DIFF
--- a/Classes/Aspect/CollectDebugInformationAspect.php
+++ b/Classes/Aspect/CollectDebugInformationAspect.php
@@ -113,7 +113,8 @@ class CollectDebugInformationAspect
             $output = $response->getBody()?->getContents();
             $response->getBody()?->rewind();
 
-            if ($response->getHeader('Content-Type') !== 'text/html' && !str_contains($output, '<!DOCTYPE html>')) {
+            $contentType = $response->getHeaderLine('Content-Type');
+            if (!str_contains($contentType, 'text/html') && !str_contains($output, '<!DOCTYPE html')) {
                 return $response;
             }
         } else {


### PR DESCRIPTION
This change allows more variants of html like content type and doctypes without disabling debug info collection.

Resolves: #21