### PR TITLE
FEATURE: Highlight slow queries

### DIFF
--- a/Resources/Private/Scripts/features/sql/QueryTable.tsx
+++ b/Resources/Private/Scripts/features/sql/QueryTable.tsx
@@ -42,7 +42,7 @@ const styles = css`
 const QueryTable: FunctionComponent = () => {
     const {
         debugInfos: {
-            sqlData: { groupedQueries }
+            sqlData: { groupedQueries, slowQueries }
         }
     } = useDebugContext();
 
@@ -62,7 +62,11 @@ const QueryTable: FunctionComponent = () => {
                         return groupedQueries[b].executionTimeSum - groupedQueries[a].executionTimeSum;
                     })
                     .map((tableName) => (
-                        <QueryTableGroup tableName={tableName} queryGroup={groupedQueries[tableName]} />
+                        <QueryTableGroup
+                            tableName={tableName}
+                            queryGroup={groupedQueries[tableName]}
+                            slowQueries={slowQueries}
+                        />
                     ))}
             </tbody>
         </table>

--- a/Resources/Private/Scripts/features/sql/QueryTableGroup.tsx
+++ b/Resources/Private/Scripts/features/sql/QueryTableGroup.tsx
@@ -3,8 +3,10 @@ import { useState } from "preact/hooks";
 
 import { css } from "../../styles/css";
 import QueryTableRow from "./QueryTableRow";
+import { classnames } from "../../helper/classnames";
+import {Icon, iconWarning} from "../../presentationals/Icon";
 
-const tableNameStyle = css`
+const tableRowStyle = css`
     cursor: pointer;
     
     &:hover {
@@ -20,19 +22,37 @@ const tableNameStyle = css`
     }
 `;
 
+const slowQueryStyle = css`
+    svg {
+        color: var(--colors-Warn);
+    }
+`;
+
+const tableNameStyle = css`
+    display: inline-flex;
+    gap: 1ch;
+`;
+
 interface QueryTableGroupProps {
     tableName: string;
     queryGroup: QueryGroup;
+    slowQueries: SlowQuery[];
 }
 
-const QueryTableGroup: FunctionComponent<QueryTableGroupProps> = ({ tableName, queryGroup }) => {
+const QueryTableGroup: FunctionComponent<QueryTableGroupProps> = ({ tableName, queryGroup, slowQueries }) => {
     const [collapsed, setCollapsed] = useState(true);
+
+    const slowQueriesForTable = slowQueries.filter((slowQuery) => slowQuery.table === tableName);
 
     return (
         <>
-            <tr className={tableNameStyle} onClick={() => setCollapsed((prev) => !prev)}>
+            <tr className={classnames(tableRowStyle, slowQueriesForTable.length > 0 && slowQueryStyle)} onClick={() => setCollapsed((prev) => !prev)}>
                 <td>
-                    {collapsed ? "▶" : "▼"} <strong>{tableName}</strong>
+                    <span className={tableNameStyle}>
+                        {collapsed ? "▶" : "▼"}
+                        {slowQueriesForTable.length > 0 && <Icon icon={iconWarning}/>}
+                        <strong>{tableName}</strong>
+                    </span>
                 </td>
                 <td>{queryGroup.executionTimeSum.toFixed(2)} ms</td>
                 <td>{queryGroup.count}</td>
@@ -45,6 +65,7 @@ const QueryTableGroup: FunctionComponent<QueryTableGroupProps> = ({ tableName, q
                     <QueryTableRow
                         queryString={sqlString}
                         queryDetails={queryGroup.queries[sqlString]}
+                        slowQueries={slowQueriesForTable.filter(({sql}) => sql === sqlString)}
                     />
                 ))}
         </>

--- a/Resources/Private/Scripts/helper/classnames.ts
+++ b/Resources/Private/Scripts/helper/classnames.ts
@@ -1,0 +1,3 @@
+export function classnames(...args: (string | boolean | undefined | null)[]): string {
+    return args.filter(Boolean).join(' ');
+}

--- a/Resources/Private/Scripts/typings/global.d.ts
+++ b/Resources/Private/Scripts/typings/global.d.ts
@@ -43,6 +43,16 @@ type QueryGroup = {
     count: number;
 }
 
+type SlowQuery = {
+    executionMS: number;
+    params: {
+        [key: string]: any;
+    };
+    sql: SQLQueryString;
+    table: SQLTableName;
+    types: number[];
+}
+
 type DebugInfos = {
     renderTime: number;
     startRenderAt: number;
@@ -50,7 +60,7 @@ type DebugInfos = {
     sqlData: {
         queryCount: number;
         executionTime: number;
-        slowQueries: SQLQueryString[];
+        slowQueries: SlowQuery[];
         tables: {
             [key: SQLTableName]: {
                 queryCount: number;


### PR DESCRIPTION
With this change, the information about slow queries is used to highlight the affected queries in the sql query list.

* A orange warning icon is used to show this state #20 
* The parameter groups are now sorted by their usage count
* The parameters don't cause horizontal overflow anymore, resolves #19 

## Before:

<img width="2560" height="2044" alt="CleanShot 2025-07-29 at 14 01 05@2x" src="https://github.com/user-attachments/assets/bcdba3bf-82eb-4048-807e-5d86535f04fa" />

## Now:

<img width="2566" height="2046" alt="CleanShot 2025-07-29 at 13 58 56@2x" src="https://github.com/user-attachments/assets/7c30127f-5061-4eff-afc1-7d86c409dea4" />
